### PR TITLE
fix `ensureDirectoryExists` uses storage disk

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .idea
+.phpunit.cache/*
 .phpunit.result.cache
 build
 composer.lock

--- a/.phpunit.cache/test-results
+++ b/.phpunit.cache/test-results
@@ -1,0 +1,1 @@
+{"version":"pest_2.34.7","defects":[],"times":{"P\\Tests\\OpenGraphTest::__pest_evaluable_it_can_generate_an_image_using_params":0.003}}

--- a/.phpunit.cache/test-results
+++ b/.phpunit.cache/test-results
@@ -1,1 +1,0 @@
-{"version":"pest_2.34.7","defects":[],"times":{"P\\Tests\\OpenGraphTest::__pest_evaluable_it_can_generate_an_image_using_params":0.003}}

--- a/src/Http/Controllers/LaravelOpenGraphImageController.php
+++ b/src/Http/Controllers/LaravelOpenGraphImageController.php
@@ -3,7 +3,6 @@
 namespace Vormkracht10\LaravelOpenGraphImage\Http\Controllers;
 
 use Illuminate\Http\Request;
-use Illuminate\Support\Facades\File;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Facades\View;
 use Spatie\Browsershot\Browsershot;

--- a/src/Http/Controllers/LaravelOpenGraphImageController.php
+++ b/src/Http/Controllers/LaravelOpenGraphImageController.php
@@ -97,12 +97,12 @@ class LaravelOpenGraphImageController
 
     public function ensureDirectoryExists()
     {
-        if (! File::isDirectory($this->getStoragePath())) {
-            File::makeDirectory($this->getStoragePath(), 0777, true);
+        if (! $this->getStorageDisk()->exists($this->getStoragePath())) {
+            $this->getStorageDisk()->makeDirectory($this->getStoragePath());
         }
     }
 
-    public function getScreenshot($html, $filename)
+    public function getScreenshot($html)
     {
         $browsershot = Browsershot::html($html)
             ->noSandbox()
@@ -118,15 +118,14 @@ class LaravelOpenGraphImageController
             $browsershot = $browsershot->setNpmBinary(config('open-graph-image.paths.npm'));
         }
 
-        return $browsershot
-            ->screenshot($this->getStorageFilePath($filename));
+        return $browsershot->screenshot();
     }
 
     public function saveOpenGraphImage($html, $filename)
     {
         $this->ensureDirectoryExists();
 
-        $screenshot = $this->getScreenshot($html, $filename);
+        $screenshot = $this->getScreenshot($html);
 
         $this->getStorageDisk()
             ->put($this->getStorageFilePath($filename), $screenshot);


### PR DESCRIPTION
Fixes the method `ensureDirectoryExists` to use the storage disk passed in the config, otherwise it attempts to create the directory `social/open-graph` in the projects root directory instead of the intended storage disk path.