### PR TITLE
Require a valid signature on the og-image file route

### DIFF
--- a/src/Http/Controllers/OgImageController.php
+++ b/src/Http/Controllers/OgImageController.php
@@ -10,7 +10,12 @@ class OgImageController
 {
     public function __invoke(Request $request): Response
     {
-        if (! app()->environment('local') && ! $request->hasValidSignature()) {
+        // The local-only preview route (og-image.html) renders HTML and never
+        // saves a file, so it may be viewed without a signature. Every other
+        // request generates/serves a cached image keyed by the signature, so a
+        // valid signature is required — otherwise saveImage() receives a null
+        // filename and throws a TypeError.
+        if ($request->route()->getName() !== 'og-image.html' && ! $request->hasValidSignature()) {
             abort(403);
         }
 

--- a/src/OgImage.php
+++ b/src/OgImage.php
@@ -214,6 +214,10 @@ class OgImage
             ]);
         }
 
+        if (! is_string($request->signature) || $request->signature === '') {
+            abort(404);
+        }
+
         OgImage::saveImage($html, $request->signature);
 
         return response(OgImage::getStorageImageFileData($request->signature), 200, [

--- a/tests/OpenGraphTest.php
+++ b/tests/OpenGraphTest.php
@@ -10,3 +10,16 @@ it('can generate an image using params', function (): void {
 
     expect($image)->toBeString();
 });
+
+it('aborts unsigned requests to the file route instead of crashing', function (): void {
+    // Regression: an unsigned request used to reach saveImage() with a null
+    // signature and throw a TypeError. It must now be rejected cleanly.
+    $this->get(route('og-image.file', ['title' => 'title'], false))
+        ->assertForbidden();
+});
+
+it('serves an image for a validly signed file url', function (): void {
+    $url = OgImage::url(['title' => 'title', 'subtitle' => 'subtitle']);
+
+    $this->get($url)->assertOk();
+})->skip(fn () => empty(shell_exec('command -v chromium')) && empty(shell_exec('command -v google-chrome')), 'No Chrome/Chromium binary available');

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -2,6 +2,7 @@
 
 namespace Backstage\OgImage\Laravel\Tests;
 
+use Backstage\OgImage\Laravel\Facades\OgImage;
 use Backstage\OgImage\Laravel\OgImageServiceProvider;
 use Orchestra\Testbench\TestCase as BaseTestCase;
 
@@ -19,7 +20,7 @@ abstract class TestCase extends BaseTestCase
     protected function getPackageAliases($app)
     {
         return [
-            'OgImage' => \Backstage\OgImage\Laravel\Facades\OgImage::class,
+            'OgImage' => OgImage::class,
         ];
     }
 }


### PR DESCRIPTION
## What's changed

- Unsigned requests to the og-image **file route** are now rejected with a 403, even in the local environment. Previously they passed the environment check and reached `saveImage()` with a `null` signature, throwing a `TypeError`.
- Only the local-only HTML preview route (`og-image.html`) remains exempt from signature validation, since it renders HTML and never writes a file.
- `generateImage()` now aborts with a 404 when the signature is missing or empty, as a defense-in-depth guard.

## Tests

- Regression test: unsigned request to the file route returns 403 instead of crashing.
- New test: a validly signed URL serves an image (skipped when no Chrome/Chromium binary is available).

🤖 Generated with [Claude Code](https://claude.com/claude-code)