### PR TITLE
Allow unsigned og-image requests in local development

### DIFF
--- a/src/Http/Controllers/OgImageController.php
+++ b/src/Http/Controllers/OgImageController.php
@@ -10,12 +10,12 @@ class OgImageController
 {
     public function __invoke(Request $request): Response
     {
-        // The local-only preview route (og-image.html) renders HTML and never
-        // saves a file, so it may be viewed without a signature. Every other
-        // request generates/serves a cached image keyed by the signature, so a
-        // valid signature is required — otherwise saveImage() receives a null
-        // filename and throws a TypeError.
-        if ($request->route()->getName() !== 'og-image.html' && ! $request->hasValidSignature()) {
+        // In local development the image always renders, regardless of signature,
+        // so previews work while iterating. Outside local a valid signature is
+        // required. getResponse() derives a cache filename from the request
+        // parameters when no signature is present, so an unsigned local request
+        // never reaches saveImage() with a null filename.
+        if (! app()->environment('local') && ! $request->hasValidSignature()) {
             abort(403);
         }
 

--- a/src/OgImage.php
+++ b/src/OgImage.php
@@ -214,17 +214,39 @@ class OgImage
             ]);
         }
 
-        if (! is_string($request->signature) || $request->signature === '') {
-            abort(404);
-        }
+        // Signed requests are cached by their signature. Unsigned requests are
+        // only allowed in local development (see the controller); there is no
+        // signature to key the cache on, so derive a stable filename from the
+        // request parameters instead. This keeps local previews working without
+        // passing a null filename to saveImage().
+        $filename = OgImage::getRequestImageFilename($request);
 
-        OgImage::saveImage($html, $request->signature);
+        OgImage::saveImage($html, $filename);
 
-        return response(OgImage::getStorageImageFileData($request->signature), 200, [
+        return response(OgImage::getStorageImageFileData($filename), 200, [
             'Cache-Control' => 'no-store, no-cache, must-revalidate, max-age=0, post-check=0, pre-check=0',
             'Content-Type' => OgImage::getImageMimeType(),
             'Pragma' => 'no-cache',
         ]);
+    }
+
+    /**
+     * Resolve the cache filename (without extension) for an incoming image
+     * request: the signed-URL signature when present, otherwise a deterministic
+     * hash of the request parameters (used for unsigned local-development
+     * requests).
+     */
+    public function getRequestImageFilename(Request $request): string
+    {
+        if (is_string($request->signature) && $request->signature !== '') {
+            return $request->signature;
+        }
+
+        $parameters = $request->except('signature');
+
+        ksort($parameters);
+
+        return hash('sha256', json_encode($parameters));
     }
 
     private function injectJs(): string

--- a/tests/OpenGraphTest.php
+++ b/tests/OpenGraphTest.php
@@ -1,6 +1,9 @@
 <?php
 
 use Backstage\OgImage\Laravel\Facades\OgImage;
+use Illuminate\Http\Request;
+
+$hasChrome = fn (): bool => ! empty(shell_exec('command -v chromium')) || ! empty(shell_exec('command -v google-chrome')) || ! empty(shell_exec('command -v google-chrome-stable'));
 
 it('can generate an image using params', function (): void {
     $image = OgImage::createImageFromParams([
@@ -11,15 +14,35 @@ it('can generate an image using params', function (): void {
     expect($image)->toBeString();
 });
 
-it('aborts unsigned requests to the file route instead of crashing', function (): void {
-    // Regression: an unsigned request used to reach saveImage() with a null
-    // signature and throw a TypeError. It must now be rejected cleanly.
-    $this->get(route('og-image.file', ['title' => 'title'], false))
-        ->assertForbidden();
-});
-
 it('serves an image for a validly signed file url', function (): void {
     $url = OgImage::url(['title' => 'title', 'subtitle' => 'subtitle']);
 
     $this->get($url)->assertOk();
-})->skip(fn () => empty(shell_exec('command -v chromium')) && empty(shell_exec('command -v google-chrome')), 'No Chrome/Chromium binary available');
+})->skip(fn (): bool => ! $hasChrome(), 'No Chrome/Chromium binary available');
+
+it('forbids unsigned file requests outside local', function (): void {
+    // Regression: an unsigned request used to reach saveImage() with a null
+    // signature and throw a TypeError. Outside local it must be rejected.
+    app()->detectEnvironment(fn () => 'production');
+
+    $this->get(route('og-image.file', ['title' => 'title'], false))
+        ->assertForbidden();
+});
+
+it('renders an unsigned file request in local development', function (): void {
+    // In local development the image always loads regardless of signature; a
+    // stable filename is derived from the request params instead of a signature.
+    app()->detectEnvironment(fn () => 'local');
+
+    $this->get(route('og-image.file', ['title' => 'title'], false))
+        ->assertOk();
+})->skip(fn (): bool => ! $hasChrome(), 'No Chrome/Chromium binary available');
+
+it('derives a stable filename from params when unsigned', function (): void {
+    $request = Request::create(route('og-image.file', ['title' => 'title', 'subtitle' => 'sub'], false));
+
+    $a = OgImage::getRequestImageFilename($request);
+    $b = OgImage::getRequestImageFilename($request);
+
+    expect($a)->toBeString()->not->toBeEmpty()->and($a)->toBe($b);
+});


### PR DESCRIPTION
## What's changed

Follow-up to #44, which required a signature on every file-route request and thereby broke unsigned previews in local development.

- The local-environment exemption from signature validation is restored, so previews keep working while iterating locally.
- Unsigned local requests have no signature to key the image cache on, so `getRequestImageFilename()` derives a deterministic SHA-256 filename from the sorted request parameters instead of passing `null` to `saveImage()`.
- Outside the local environment, unsigned requests are still rejected with a 403 (regression test included).

## Tests

- Unsigned file request outside local → 403.
- Unsigned file request in local development renders (skipped without a Chrome/Chromium binary).
- Filename derivation is stable and non-empty for unsigned requests.
- Validly signed URL serves an image (skipped without a Chrome/Chromium binary).

🤖 Generated with [Claude Code](https://claude.com/claude-code)